### PR TITLE
Fix number parameter not being optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ Add and manage testimonial quotes via the Django admin console.
 
 ## Change Log
 
+### 2.0.5
+
+* Make `number` parameter optional in `testimonials` templatetag
+* Add unit test to verify all active testimonials are returned
+
 ### 2.0.4
 
 * Add django>=1.11 to requirements

--- a/pinax/testimonials/templatetags/pinax_testimonials_tags.py
+++ b/pinax/testimonials/templatetags/pinax_testimonials_tags.py
@@ -17,5 +17,5 @@ def random_testimonial():
 
 
 @register.simple_tag
-def testimonials(number):
+def testimonials(number=None):
     return Testimonial.objects.filter(active=True).order_by("-added")[:number]

--- a/pinax/testimonials/tests/tests.py
+++ b/pinax/testimonials/tests/tests.py
@@ -54,3 +54,6 @@ class TestTags(TestCase):
         """
         testimonials = testimonials_tag(3)
         self.assertSequenceEqual(testimonials, [self.third, self.second, self.first])
+
+        testimonials = testimonials_tag()
+        self.assertSequenceEqual(testimonials, [self.third, self.second, self.first])

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "2.0.4"
+VERSION = "2.0.5"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-testimonials.svg
     :target: https://pypi.python.org/pypi/pinax-testimonials/


### PR DESCRIPTION
Fixes #17.

Changes proposed in this PR:

- Add a default value to the `testimonials` templatetag so the `number` parameter is actually optional.
- Correct the code to match the documentation
- Bump the version number
- Update changelog in README